### PR TITLE
fix dkim keyfile

### DIFF
--- a/config/example/opendkim.conf
+++ b/config/example/opendkim.conf
@@ -14,7 +14,7 @@ Syslog                  yes
 # Sign for example.com with key in /etc/mail/dkim.key using
 # selector '2007' (e.g. 2007._domainkey.example.com)
 Domain                  example.com
-KeyFile                 /etc/mail/dkim.key # See bellow how to generate and set up the key
+KeyFile                 /etc/dkim.key # See bellow how to generate and set up the key
 Selector                mail
 
 # Common settings. See dkim-filter.conf(5) for more information.


### PR DESCRIPTION
process_settings copies the key file to /etc, not /etc/mail