### PR TITLE
Restart docker core bug

### DIFF
--- a/core/boot
+++ b/core/boot
@@ -27,7 +27,7 @@ cp /mail_settings/aliases /etc/postfix/virtual
 cp /mail_settings/domains /etc/postfix/virtual-mailbox-domains
 
 # Parse mailbox settings
-mkdir /etc/postfix/tmp
+mkdir -p /etc/postfix/tmp
 awk < /etc/postfix/virtual '{ print $2 }' > /etc/postfix/tmp/virtual-receivers
 sed -r 's,(.+)@(.+),\2/\1/,' /etc/postfix/tmp/virtual-receivers > /etc/postfix/tmp/virtual-receiver-folders
 paste /etc/postfix/tmp/virtual-receivers /etc/postfix/tmp/virtual-receiver-folders > /etc/postfix/virtual-mailbox-maps

--- a/core/boot.d/rsyslog
+++ b/core/boot.d/rsyslog
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -f /var/run/rsyslogd.pid ]; then
+	echo "Stopping running syslog"
+	rm /var/run/rsyslogd.pid
+fi
+


### PR DESCRIPTION
Hi,
i changed the boot script and added a new boot file in boot.d, so that the docker container can be stopped and started again with docker.
Before the container could not be started after, it was stopped,because rsyslogd was complaining about an existing pid which exists and is wrong. 

I did not test it in combination with amavis and opendkim container, because i use in the moment only the core mailer. Feel free to change the location of the changes, because i did not know if they are in the best places.

Thanks for the very good work you did with creating this containers.
